### PR TITLE
remove reference to makefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ set(SOURCE_FILES
         src/keccak/sha3.c
         src/keccak/sha3.h
         src/main.c
-        src/main.h
-        Makefile)
+        src/main.h)
 
 add_executable(c_light_wallet ${SOURCE_FILES})


### PR DESCRIPTION
Hey,

Great work, heard about your library on the IOTA discord :)
I tried to make your project work but the CMakelists is referencing a Makefile that does not exist.
I saw a Makefile on some other branches, but I guess it is not used anymore on the master branch?

Best